### PR TITLE
Refactor - Removal of ViewModel instances down to other composables

### DIFF
--- a/feature/home/src/main/kotlin/com/skydoves/pokedex/compose/feature/home/PokedexHome.kt
+++ b/feature/home/src/main/kotlin/com/skydoves/pokedex/compose/feature/home/PokedexHome.kt
@@ -171,7 +171,6 @@ private fun SharedTransitionScope.PokemonCard(
       imageOptions = ImageOptions(contentScale = ContentScale.Inside),
       component = rememberImageComponent {
         +CrossfadePlugin()
-
         +ShimmerPlugin(
           Shimmer.Resonate(
             baseColor = Color.Transparent,
@@ -188,7 +187,7 @@ private fun SharedTransitionScope.PokemonCard(
         }
       },
       previewPlaceholder = painterResource(
-        id = R.drawable.pokemon_preview
+        id = R.drawable.pokemon_preview,
       ),
     )
 

--- a/feature/home/src/main/kotlin/com/skydoves/pokedex/compose/feature/home/PokedexHome.kt
+++ b/feature/home/src/main/kotlin/com/skydoves/pokedex/compose/feature/home/PokedexHome.kt
@@ -74,6 +74,7 @@ import com.skydoves.pokedex.compose.core.navigation.boundsTransform
 import com.skydoves.pokedex.compose.core.navigation.currentComposeNavigator
 import com.skydoves.pokedex.compose.core.preview.PokedexPreviewTheme
 import com.skydoves.pokedex.compose.core.preview.PreviewUtils
+import com.skydoves.pokedex.compose.designsystem.R
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.toImmutableList
 
@@ -92,7 +93,7 @@ fun SharedTransitionScope.PokedexHome(
       animatedVisibilityScope = animatedVisibilityScope,
       uiState = uiState,
       pokemonList = pokemonList.toImmutableList(),
-      homeViewModel = homeViewModel,
+      fetchNextPokemonList = homeViewModel::fetchNextPokemonList,
     )
   }
 }
@@ -102,7 +103,7 @@ private fun SharedTransitionScope.HomeContent(
   animatedVisibilityScope: AnimatedVisibilityScope,
   uiState: HomeUiState,
   pokemonList: ImmutableList<Pokemon>,
-  homeViewModel: HomeViewModel,
+  fetchNextPokemonList: () -> Unit,
 ) {
   Box(modifier = Modifier.fillMaxSize()) {
     val threadHold = 8
@@ -113,7 +114,7 @@ private fun SharedTransitionScope.HomeContent(
     ) {
       itemsIndexed(items = pokemonList, key = { _, pokemon -> pokemon.name }) { index, pokemon ->
         if ((index + threadHold) >= pokemonList.size && uiState != HomeUiState.Loading) {
-          homeViewModel.fetchNextPokemonList()
+          fetchNextPokemonList()
         }
 
         PokemonCard(
@@ -187,7 +188,7 @@ private fun SharedTransitionScope.PokemonCard(
         }
       },
       previewPlaceholder = painterResource(
-        id = com.skydoves.pokedex.compose.designsystem.R.drawable.pokemon_preview,
+        id = R.drawable.pokemon_preview
       ),
     )
 
@@ -236,7 +237,7 @@ private fun HomeContentPreview() {
       animatedVisibilityScope = scope,
       uiState = HomeUiState.Idle,
       pokemonList = PreviewUtils.mockPokemonList().toImmutableList(),
-      homeViewModel = HomeViewModel(homeRepository = FakeHomeRepository()),
+      fetchNextPokemonList = { HomeViewModel(homeRepository = FakeHomeRepository()) },
     )
   }
 }


### PR DESCRIPTION

### 🎯 Goal
This pull request aims to refactor the code by addressing to not to pass a ViewModel instance as a parameter. The fix involves adhering to best practices outlined in the Architecture state holders documentation, which advises against passing ViewModel instances to other composables. Instead, we use a lambda expression to invoke the required method, ensuring cleaner and more maintainable code.

By making this change, we enhance code readability, adhere to recommended architecture patterns, and ensure better maintainability of the project in the long run.

### 🛠 Implementation details
By hoisting the `fetchNextPokemonList` function call to the parent composable (also HomeContentPreview()), we adhere to the principle of separating concerns and maintain a clear distinction between UI logic and business logic. This makes the codebase more modular, easier to understand, and less prone to errors.

### ✍️ Explain examples
Explain examples with code for this updates.

### Preparing a pull request for review
Ensure your change is properly formatted by running:

```gradle
$ ./gradlew spotlessApply
```

Please correct any failures before requesting a review.