### PR TITLE
Fixed Text clipping issue during transition animations.

### DIFF
--- a/feature/home/src/main/kotlin/com/skydoves/pokedex/compose/feature/home/PokedexHome.kt
+++ b/feature/home/src/main/kotlin/com/skydoves/pokedex/compose/feature/home/PokedexHome.kt
@@ -200,7 +200,8 @@ private fun SharedTransitionScope.PokemonCard(
           state = rememberSharedContentState(key = "name-${pokemon.name}"),
           animatedVisibilityScope = animatedVisibilityScope,
           boundsTransform = boundsTransform,
-        ).padding(12.dp),
+        )
+        .padding(12.dp),
       text = pokemon.name,
       color = PokedexTheme.colors.black,
       textAlign = TextAlign.Center,

--- a/feature/home/src/main/kotlin/com/skydoves/pokedex/compose/feature/home/PokedexHome.kt
+++ b/feature/home/src/main/kotlin/com/skydoves/pokedex/compose/feature/home/PokedexHome.kt
@@ -194,14 +194,13 @@ private fun SharedTransitionScope.PokemonCard(
     Text(
       modifier = Modifier
         .align(Alignment.CenterHorizontally)
-        .padding(12.dp)
         .fillMaxWidth()
         .pokedexSharedElement(
           isLocalInspectionMode = LocalInspectionMode.current,
           state = rememberSharedContentState(key = "name-${pokemon.name}"),
           animatedVisibilityScope = animatedVisibilityScope,
           boundsTransform = boundsTransform,
-        ),
+        ).padding(12.dp),
       text = pokemon.name,
       color = PokedexTheme.colors.black,
       textAlign = TextAlign.Center,


### PR DESCRIPTION
### 🎯 Goal
The changes in this pull request address an issue where text were being cut off during transition animations from HomeScreen to DetailScreen.

**Current Behavior**

https://github.com/skydoves/pokedex-compose/assets/34919679/28d71b4b-177b-4b88-8004-5d0614c6ed32

**After Fix Behavior**

https://github.com/skydoves/pokedex-compose/assets/34919679/1beafb04-b160-4389-9871-a342c7842f5e

### 🛠 Implementation details
This Pull Request addresses a text clipping issue during transition animations by rearranging the modifier property for the Text composable within the PokemonCard component. By moving the padding configuration after the pokedexSharedElement modifier, we ensure proper padding application without affecting the shared transition behavior. These changes helps resolving text clipping problems while maintaining code readability and adherence to best practices.

### ✍️ Explain examples
Explain examples with code for this updates.

### Preparing a pull request for review
Ensure your change is properly formatted by running:

```gradle
$ ./gradlew spotlessApply
```

Please correct any failures before requesting a review.