### PR TITLE
[Fix] Modifying the targetSdk version of Convention Plugin

### DIFF
--- a/build-logic/convention/src/main/kotlin/AndroidApplicationConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidApplicationConventionPlugin.kt
@@ -14,7 +14,7 @@ class AndroidApplicationConventionPlugin : Plugin<Project> {
 
       extensions.configure<BaseAppModuleExtension> {
         configureKotlinAndroid(this)
-        defaultConfig.targetSdk = 32
+        defaultConfig.targetSdk = 34
       }
     }
   }

--- a/build-logic/convention/src/main/kotlin/AndroidLibraryConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidLibraryConventionPlugin.kt
@@ -14,7 +14,7 @@ class AndroidLibraryConventionPlugin : Plugin<Project> {
 
       extensions.configure<LibraryExtension> {
         configureKotlinAndroid(this)
-        defaultConfig.targetSdk = 32
+        defaultConfig.targetSdk = 34
       }
     }
   }


### PR DESCRIPTION
### 🎯 Goal
The `targetSdk` version in the `libs.versions.toml` file is set to `34`, but it was set to `32` in the `ConventionPlugin`. Additionally, the `compileSdk` version has also been confirmed to be set to `34`. From what I understand, for the safety and security of the app, the `compileSdk` and `targetSdk` versions should be the same. Therefore, I request that the `compileSdk` and `targetSdk` versions be unified.
![image](https://github.com/skydoves/pokedex-compose/assets/54674781/b2e2f5aa-3ca5-407b-aebc-3f9372caa2d8)

### 🛠 Implementation details

```
:build-logic/../AndroidApplicationConvetionPlugin.kt
... 
extensions.configure<BaseAppModuleExtension> {
        configureKotlinAndroid(this)
        defaultConfig.targetSdk = 32 // Modified to 34 
      }
...
```
```
:build-logic/../AndroidLibraryConventionPlugin.kt
... 
extensions.configure<LibraryExtension> {
        configureKotlinAndroid(this)
        defaultConfig.targetSdk = 32 // Modified to 34 
      }
...
```

### ✍️ Explain examples
Explain examples with code for this updates.

### Preparing a pull request for review
Ensure your change is properly formatted by running:

```gradle
$ ./gradlew spotlessApply
```

Please correct any failures before requesting a review.