### PR TITLE
Fix tests

### DIFF
--- a/core/data/src/test/kotlin/com/skydoves/pokedex/compose/core/data/DetailsRepositoryTest.kt
+++ b/core/data/src/test/kotlin/com/skydoves/pokedex/compose/core/data/DetailsRepositoryTest.kt
@@ -69,10 +69,10 @@ class DetailsRepositoryTest {
     )
 
     repository.fetchPokemonInfo(name = "bulbasaur", onComplete = {}, onError = {}).test {
-      val expectItem = awaitItem()
-      assertEquals(expectItem.id, mockData.id)
-      assertEquals(expectItem.name, mockData.name)
-      assertEquals(expectItem, mockData)
+      val actualItem = awaitItem()
+      assertEquals(mockData.id, actualItem.id)
+      assertEquals(mockData.name, actualItem.name)
+      assertEquals(mockData, actualItem)
       awaitComplete()
     }
 

--- a/core/data/src/test/kotlin/com/skydoves/pokedex/compose/core/data/HomeRepositoryImplTest.kt
+++ b/core/data/src/test/kotlin/com/skydoves/pokedex/compose/core/data/HomeRepositoryImplTest.kt
@@ -77,10 +77,11 @@ class HomeRepositoryImplTest {
       onComplete = {},
       onError = {},
     ).test(2.toDuration(DurationUnit.SECONDS)) {
-      val expectItem = awaitItem()[0]
-      assertEquals(expectItem.page, 0)
-      assertEquals(expectItem.name, "bulbasaur")
-      assertEquals(expectItem, mockPokemonList()[0])
+      val actualItem = awaitItem()[0]
+      assertEquals(0, actualItem.page)
+      // First letter of name is always upper case
+      assertEquals("Bulbasaur", actualItem.name)
+      assertEquals("https://pokeapi.co/api/v2/pokemon/1/", actualItem.url)
       awaitComplete()
     }
 
@@ -103,10 +104,11 @@ class HomeRepositoryImplTest {
       onComplete = {},
       onError = {},
     ).test(2.toDuration(DurationUnit.SECONDS)) {
-      val expectItem = awaitItem()[0]
-      assertEquals(expectItem.page, 0)
-      assertEquals(expectItem.name, "bulbasaur")
-      assertEquals(expectItem, mockPokemonList()[0])
+      val actualItem = awaitItem()[0]
+      assertEquals(0, actualItem.page)
+      // First letter of name is always upper case
+      assertEquals("Bulbasaur", actualItem.name)
+      assertEquals("https://pokeapi.co/api/v2/pokemon/1/", actualItem.url)
       awaitComplete()
     }
 


### PR DESCRIPTION
### 🎯 Goal
Some tests are failing with an incorrect error message. This fixes the tests and the error messages.

### 🛠 Implementation details
- Properly test that the Pokemon names first letter is upper case. The `name` field of the `Pokemon` class is transforming `nameField` to always return the first letter as upper case, but some tests used the incorrect expected value with first letter as lower case.
- Invert **expect** and **actual** arguments in assertions. Expect is the _hardcoded_ part of the assertion and is the first argument in all JUnit assertion methods. Actual is the result of the test and is the second argument.