### PR TITLE
Use the official Kotlin Serialization converter from Retrofit and remove references to Moshi

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Go to the [Releases](https://github.com/skydoves/pokedex-compose/releases) to do
   - Repository Pattern: Acts as a mediator between different data sources and the application's business logic.
 - [Retrofit2 & OkHttp3](https://github.com/square/retrofit): Constructs REST APIs and facilitates paging network data retrieval.
 - [Sandwich](https://github.com/skydoves/Sandwich): Adaptable and lightweight sealed API library designed for handling API responses and exceptions in Kotlin for Retrofit, Ktor, and Kotlin Multiplatform.
-- [Moshi](https://github.com/square/moshi/): A modern JSON library compatible with Kotlin and Java.
+- [Kotlin Serialization](https://github.com/Kotlin/kotlinx.serialization): Kotlin multiplatform / multi-format reflectionless serialization.
 - [ksp](https://github.com/google/ksp): Kotlin Symbol Processing API for code generation and analysis.
 - [Turbine](https://github.com/cashapp/turbine): A small testing library for kotlinx.coroutines Flow.
 - [Landscapist Glide](https://github.com/skydoves/landscapist#glide), [animation](https://github.com/skydoves/landscapist#animation), [placeholder](https://github.com/skydoves/landscapist#placeholder): A pluggable, highly optimized Jetpack Compose and Kotlin Multiplatform image loading library that fetches and displays network images with Glide, Coil, and Fresco.

--- a/build-logic/convention/src/main/kotlin/com/skydoves/pokedex/compose/AndroidCompose.kt
+++ b/build-logic/convention/src/main/kotlin/com/skydoves/pokedex/compose/AndroidCompose.kt
@@ -34,7 +34,7 @@ private fun Project.buildComposeMetricsParameters(): List<String> {
   val enableMetricsProvider = project.providers.gradleProperty("enableComposeCompilerMetrics")
   val enableMetrics = (enableMetricsProvider.orNull == "true")
   if (enableMetrics) {
-    val metricsFolder = File(project.buildDir, "compose-metrics")
+    val metricsFolder = File(project.layout.buildDirectory.asFile.get(), "compose-metrics")
     metricParameters.add("-P")
     metricParameters.add(
       "plugin:androidx.compose.compiler.plugins.kotlin:metricsDestination=" + metricsFolder.absolutePath
@@ -44,7 +44,7 @@ private fun Project.buildComposeMetricsParameters(): List<String> {
   val enableReportsProvider = project.providers.gradleProperty("enableComposeCompilerReports")
   val enableReports = (enableReportsProvider.orNull == "true")
   if (enableReports) {
-    val reportsFolder = File(project.buildDir, "compose-reports")
+    val reportsFolder = File(project.layout.buildDirectory.asFile.get(), "compose-reports")
     metricParameters.add("-P")
     metricParameters.add(
       "plugin:androidx.compose.compiler.plugins.kotlin:reportsDestination=" + reportsFolder.absolutePath

--- a/build-logic/convention/src/main/kotlin/com/skydoves/pokedex/compose/AndroidCompose.kt
+++ b/build-logic/convention/src/main/kotlin/com/skydoves/pokedex/compose/AndroidCompose.kt
@@ -29,26 +29,24 @@ internal fun Project.configureAndroidCompose(
   }
 }
 
-private fun Project.buildComposeMetricsParameters(): List<String> {
-  val metricParameters = mutableListOf<String>()
+private fun Project.buildComposeMetricsParameters(): List<String> = buildList {
   val enableMetricsProvider = project.providers.gradleProperty("enableComposeCompilerMetrics")
   val enableMetrics = (enableMetricsProvider.orNull == "true")
   if (enableMetrics) {
-    val metricsFolder = File(project.layout.buildDirectory.asFile.get(), "compose-metrics")
-    metricParameters.add("-P")
-    metricParameters.add(
-      "plugin:androidx.compose.compiler.plugins.kotlin:metricsDestination=" + metricsFolder.absolutePath
+    val metricsFolder = project.layout.buildDirectory.dir("compose-metrics").get()
+    add("-P")
+    add(
+      "plugin:androidx.compose.compiler.plugins.kotlin:metricsDestination=$metricsFolder"
     )
   }
 
   val enableReportsProvider = project.providers.gradleProperty("enableComposeCompilerReports")
   val enableReports = (enableReportsProvider.orNull == "true")
   if (enableReports) {
-    val reportsFolder = File(project.layout.buildDirectory.asFile.get(), "compose-reports")
-    metricParameters.add("-P")
-    metricParameters.add(
-      "plugin:androidx.compose.compiler.plugins.kotlin:reportsDestination=" + reportsFolder.absolutePath
+    val reportsFolder = project.layout.buildDirectory.dir("compose-reports").get()
+    add("-P")
+    add(
+      "plugin:androidx.compose.compiler.plugins.kotlin:reportsDestination=$reportsFolder"
     )
   }
-  return metricParameters.toList()
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
   alias(libs.plugins.android.test) apply false
   alias(libs.plugins.kotlin.android) apply false
   alias(libs.plugins.kotlin.parcelize) apply false
-  alias(libs.plugins.kotlin.serialization) apply false
+  alias(libs.plugins.kotlinx.serialization) apply false
   alias(libs.plugins.ksp) apply false
   alias(libs.plugins.hilt.plugin) apply false
   alias(libs.plugins.spotless)

--- a/core/data/build.gradle.kts
+++ b/core/data/build.gradle.kts
@@ -35,8 +35,7 @@ dependencies {
   api(libs.kotlinx.immutable.collection)
 
   // coroutines
-  implementation(libs.kotlinx.coroutines)
-  testImplementation(libs.kotlinx.coroutines)
+  implementation(libs.kotlinx.coroutines.android)
   testImplementation(libs.kotlinx.coroutines.test)
 
   // network

--- a/core/database/build.gradle.kts
+++ b/core/database/build.gradle.kts
@@ -43,15 +43,14 @@ dependencies {
   testImplementation(projects.core.test)
 
   // coroutines
-  implementation(libs.kotlinx.coroutines)
-  testImplementation(libs.kotlinx.coroutines)
+  implementation(libs.kotlinx.coroutines.android)
   testImplementation(libs.kotlinx.coroutines.test)
 
   // database
   implementation(libs.androidx.room.runtime)
   implementation(libs.androidx.room.ktx)
   ksp(libs.androidx.room.compiler)
-  testImplementation(libs.androidx.arch.core)
+  testImplementation(libs.androidx.arch.core.testing)
 
   // json parsing
   implementation(libs.kotlinx.serialization.json)

--- a/core/model/build.gradle.kts
+++ b/core/model/build.gradle.kts
@@ -30,7 +30,7 @@ dependencies {
   // compose stable marker
   compileOnly(libs.compose.stable.marker)
 
-  // moshi
+  // Kotlin Serialization for Json
   implementation(libs.kotlinx.serialization.json)
 
   // kotlinx

--- a/core/navigation/build.gradle.kts
+++ b/core/navigation/build.gradle.kts
@@ -13,7 +13,7 @@ android {
 dependencies {
   implementation(projects.core.model)
 
-  implementation(libs.kotlinx.coroutines)
+  implementation(libs.kotlinx.coroutines.android)
 
   implementation(libs.androidx.compose.ui)
   implementation(libs.androidx.compose.animation)

--- a/core/network/build.gradle.kts
+++ b/core/network/build.gradle.kts
@@ -34,14 +34,14 @@ dependencies {
   testImplementation(projects.core.test)
 
   // coroutines
-  implementation(libs.kotlinx.coroutines)
-  testImplementation(libs.kotlinx.coroutines)
+  implementation(libs.kotlinx.coroutines.android)
   testImplementation(libs.kotlinx.coroutines.test)
 
   // network
   implementation(libs.sandwich)
-  implementation(libs.bundles.retrofitBundle)
-  testImplementation(libs.androidx.arch.core)
+  implementation(libs.bundles.retrofit)
+  testImplementation(libs.okhttp.mockserver)
+  testImplementation(libs.androidx.arch.core.testing)
 
   // json parsing
   implementation(libs.kotlinx.serialization.json)

--- a/core/network/build.gradle.kts
+++ b/core/network/build.gradle.kts
@@ -39,8 +39,8 @@ dependencies {
 
   // network
   implementation(libs.sandwich)
-  implementation(libs.bundles.retrofit)
-  testImplementation(libs.okhttp.mockserver)
+  implementation(libs.bundles.retrofitBundle)
+  testImplementation(libs.okhttp.mockwebserver)
   testImplementation(libs.androidx.arch.core.testing)
 
   // json parsing

--- a/core/network/src/main/kotlin/com/skydoves/pokedex/compose/core/network/di/NetworkModule.kt
+++ b/core/network/src/main/kotlin/com/skydoves/pokedex/compose/core/network/di/NetworkModule.kt
@@ -16,7 +16,6 @@
 
 package com.skydoves.pokedex.compose.core.network.di
 
-import com.jakewharton.retrofit2.converter.kotlinx.serialization.asConverterFactory
 import com.skydoves.pokedex.compose.core.network.service.PokedexClient
 import com.skydoves.pokedex.compose.core.network.service.PokedexService
 import com.skydoves.pokedex.core.network.BuildConfig
@@ -30,6 +29,7 @@ import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit
+import retrofit2.converter.kotlinx.serialization.asConverterFactory
 import javax.inject.Singleton
 
 @Module
@@ -38,7 +38,7 @@ internal object NetworkModule {
 
   @Singleton
   @Provides
-  fun provideJson() = Json {
+  fun provideJson(): Json = Json {
     ignoreUnknownKeys = true
   }
 

--- a/core/network/src/test/kotlin/com/skydoves/pokedex/compose/core/network/ApiAbstract.kt
+++ b/core/network/src/test/kotlin/com/skydoves/pokedex/compose/core/network/ApiAbstract.kt
@@ -17,7 +17,6 @@
 package com.skydoves.pokedex.compose.core.network
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
-import com.jakewharton.retrofit2.converter.kotlinx.serialization.asConverterFactory
 import com.skydoves.pokedex.compose.core.test.MainCoroutinesRule
 import com.skydoves.sandwich.retrofit.adapters.ApiResponseCallAdapterFactory
 import kotlinx.serialization.json.Json
@@ -32,6 +31,7 @@ import org.junit.Rule
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 import retrofit2.Retrofit
+import retrofit2.converter.kotlinx.serialization.asConverterFactory
 import java.nio.charset.StandardCharsets
 
 @RunWith(JUnit4::class)

--- a/core/test/build.gradle.kts
+++ b/core/test/build.gradle.kts
@@ -25,7 +25,7 @@ android {
 
 dependencies {
   implementation(projects.core.model)
-  implementation(libs.kotlinx.coroutines)
+  implementation(libs.kotlinx.coroutines.android)
   implementation(libs.kotlinx.coroutines.test)
   implementation(libs.junit)
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -41,7 +41,7 @@ baselineprofile = "1.2.3"
 androidx-room-runtime = { module = "androidx.room:room-runtime", version.ref = "androidxRoom" }
 androidx-room-ktx = { module = "androidx.room:room-ktx", version.ref = "androidxRoom" }
 androidx-room-compiler = { module = "androidx.room:room-compiler", version.ref = "androidxRoom" }
-androidx-arch-core = { module = "androidx.arch.core:core-testing", version.ref = "androidxArchCore" }
+androidx-arch-core-testing = { module = "androidx.arch.core:core-testing", version.ref = "androidxArchCore" }
 androidx-startup = { module = "androidx.startup:startup-runtime", version.ref = "androidXStartup" }
 androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "androidxActivity" }
 androidx-navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "androidxComposeNavigation" }
@@ -69,9 +69,9 @@ hilt-testing = { module = "com.google.dagger:hilt-android-testing", version.ref 
 sandwich = { module = "com.github.skydoves:sandwich-retrofit", version.ref = "sandwich" }
 retrofit = { module = "com.squareup.retrofit2:retrofit", version.ref = "retrofit" }
 retrofit-kotlinSerialization = { module = "com.squareup.retrofit2:converter-kotlinx-serialization", version.ref = "retrofit" }
-okhttp-interceptor = { module = "com.squareup.okhttp3:logging-interceptor", version.ref = "okHttp" }
+okhttp-loggingInterceptor = { module = "com.squareup.okhttp3:logging-interceptor", version.ref = "okHttp" }
 okhttp-mockserver = { module = "com.squareup.okhttp3:mockwebserver", version.ref = "okHttp" }
-kotlinx-coroutines = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "coroutines" }
+kotlinx-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "coroutines" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutines" }
 kotlinx-immutable-collection = { group = "org.jetbrains.kotlinx", name = "kotlinx-collections-immutable", version.ref = "kotlinxImmutable" }
 
@@ -106,4 +106,4 @@ hilt-plugin = { id = "com.google.dagger.hilt.android", version.ref = "hilt" }
 baselineprofile = { id = "androidx.baselineprofile", version.ref = "baselineprofile" }
 
 [bundles]
-retrofitBundle = ["retrofit", "retrofit-kotlinSerialization", "okhttp-interceptor", "okhttp-mockserver"]
+retrofit = ["retrofit", "retrofit-kotlinSerialization", "okhttp-loggingInterceptor"]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -68,7 +68,7 @@ hilt-compiler = { module = "com.google.dagger:hilt-compiler", version.ref = "hil
 hilt-testing = { module = "com.google.dagger:hilt-android-testing", version.ref = "hilt" }
 sandwich = { module = "com.github.skydoves:sandwich-retrofit", version.ref = "sandwich" }
 retrofit = { module = "com.squareup.retrofit2:retrofit", version.ref = "retrofit" }
-retrofit-kotlin-serialization = { module = "com.squareup.retrofit2:converter-kotlinx-serialization", version.ref = "retrofit" }
+retrofit-kotlinSerialization = { module = "com.squareup.retrofit2:converter-kotlinx-serialization", version.ref = "retrofit" }
 okhttp-interceptor = { module = "com.squareup.okhttp3:logging-interceptor", version.ref = "okHttp" }
 okhttp-mockserver = { module = "com.squareup.okhttp3:mockwebserver", version.ref = "okHttp" }
 kotlinx-coroutines = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "coroutines" }
@@ -106,4 +106,4 @@ hilt-plugin = { id = "com.google.dagger.hilt.android", version.ref = "hilt" }
 baselineprofile = { id = "androidx.baselineprofile", version.ref = "baselineprofile" }
 
 [bundles]
-retrofitBundle = ["retrofit", "retrofit-kotlin-serialization", "okhttp-interceptor", "okhttp-mockserver"]
+retrofitBundle = ["retrofit", "retrofit-kotlinSerialization", "okhttp-interceptor", "okhttp-mockserver"]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -68,9 +68,9 @@ hilt-compiler = { module = "com.google.dagger:hilt-compiler", version.ref = "hil
 hilt-testing = { module = "com.google.dagger:hilt-android-testing", version.ref = "hilt" }
 sandwich = { module = "com.github.skydoves:sandwich-retrofit", version.ref = "sandwich" }
 retrofit = { module = "com.squareup.retrofit2:retrofit", version.ref = "retrofit" }
-retrofit-kotlinSerialization = { module = "com.squareup.retrofit2:converter-kotlinx-serialization", version.ref = "retrofit" }
-okhttp-loggingInterceptor = { module = "com.squareup.okhttp3:logging-interceptor", version.ref = "okHttp" }
-okhttp-mockserver = { module = "com.squareup.okhttp3:mockwebserver", version.ref = "okHttp" }
+retrofit-kotlin-serialization = { module = "com.squareup.retrofit2:converter-kotlinx-serialization", version.ref = "retrofit" }
+okhttp-logging-interceptor = { module = "com.squareup.okhttp3:logging-interceptor", version.ref = "okHttp" }
+okhttp-mockwebserver = { module = "com.squareup.okhttp3:mockwebserver", version.ref = "okHttp" }
 kotlinx-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "coroutines" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutines" }
 kotlinx-immutable-collection = { group = "org.jetbrains.kotlinx", name = "kotlinx-collections-immutable", version.ref = "kotlinxImmutable" }
@@ -106,4 +106,4 @@ hilt-plugin = { id = "com.google.dagger.hilt.android", version.ref = "hilt" }
 baselineprofile = { id = "androidx.baselineprofile", version.ref = "baselineprofile" }
 
 [bundles]
-retrofit = ["retrofit", "retrofit-kotlinSerialization", "okhttp-loggingInterceptor"]
+retrofitBundle = ["retrofit", "retrofit-kotlin-serialization", "okhttp-logging-interceptor"]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -68,7 +68,7 @@ hilt-compiler = { module = "com.google.dagger:hilt-compiler", version.ref = "hil
 hilt-testing = { module = "com.google.dagger:hilt-android-testing", version.ref = "hilt" }
 sandwich = { module = "com.github.skydoves:sandwich-retrofit", version.ref = "sandwich" }
 retrofit = { module = "com.squareup.retrofit2:retrofit", version.ref = "retrofit" }
-retrofit-kotlin-serialization = { module = "com.squareup.retrofit2:converter-kotlinx-serialization", version.ref = "retrofit" }
+retrofit-kotlinx-serialization = { module = "com.squareup.retrofit2:converter-kotlinx-serialization", version.ref = "retrofit" }
 okhttp-logging-interceptor = { module = "com.squareup.okhttp3:logging-interceptor", version.ref = "okHttp" }
 okhttp-mockwebserver = { module = "com.squareup.okhttp3:mockwebserver", version.ref = "okHttp" }
 kotlinx-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "coroutines" }
@@ -98,7 +98,7 @@ android-application = { id = "com.android.application", version.ref = "agp" }
 android-library = { id = "com.android.library", version.ref = "agp" }
 android-test = { id = "com.android.test", version.ref = "agp" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
-kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
+kotlinx-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 kotlin-parcelize = { id = "org.jetbrains.kotlin.plugin.parcelize", version.ref = "kotlin" }
 spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }
@@ -106,4 +106,4 @@ hilt-plugin = { id = "com.google.dagger.hilt.android", version.ref = "hilt" }
 baselineprofile = { id = "androidx.baselineprofile", version.ref = "baselineprofile" }
 
 [bundles]
-retrofitBundle = ["retrofit", "retrofit-kotlin-serialization", "okhttp-logging-interceptor"]
+retrofitBundle = ["retrofit", "retrofit-kotlinx-serialization", "okhttp-logging-interceptor"]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,11 +17,9 @@ composeStableMarker = "1.0.4"
 kotlinxSerializationJson = "1.6.3"
 hilt = "2.51.1"
 retrofit = "2.11.0"
-retrofitKotlinxSerializationJson = "1.0.0"
 okHttp = "4.12.0"
 sandwich = "2.0.7"
 landscapist = "2.3.3"
-moshi = "1.15.1"
 coroutines = "1.8.0"
 profileInstaller = "1.3.1"
 macroBenchmark = "1.2.3"
@@ -70,7 +68,7 @@ hilt-compiler = { module = "com.google.dagger:hilt-compiler", version.ref = "hil
 hilt-testing = { module = "com.google.dagger:hilt-android-testing", version.ref = "hilt" }
 sandwich = { module = "com.github.skydoves:sandwich-retrofit", version.ref = "sandwich" }
 retrofit = { module = "com.squareup.retrofit2:retrofit", version.ref = "retrofit" }
-retrofit-kotlin-serialization = { group = "com.jakewharton.retrofit", name = "retrofit2-kotlinx-serialization-converter", version.ref = "retrofitKotlinxSerializationJson" }
+retrofit-kotlin-serialization = { module = "com.squareup.retrofit2:converter-kotlinx-serialization", version.ref = "retrofit" }
 okhttp-interceptor = { module = "com.squareup.okhttp3:logging-interceptor", version.ref = "okHttp" }
 okhttp-mockserver = { module = "com.squareup.okhttp3:mockwebserver", version.ref = "okHttp" }
 kotlinx-coroutines = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "coroutines" }


### PR DESCRIPTION
### 🎯 Goal
Remove a deprecated dependency and fix comments and documentation to reflect the actual libraries used in the project.

### 🛠 Implementation details
- Use the official Kotlin Serialization converter from Retrofit instead of the deprecated library from Jake Wharton.
- Remove unused versions.
- Remove comments referencing Moshi.
- Update the Readme file to mention Kotlin Serialization instead of Moshi.
- Use "kotlinSerialization" as single dependency component instead of creating an empty "kotlin" subcomponent.
- Declare OkHttp mock web server as a test dependency instead of a main dependency.
- Rename some dependencies to be more explicit about what they are.
- Replace deprecated call to `project.buildDir` in AndroidCompose convention plugin.