### PR TITLE
Migrate kotlinOptions to compilerOptions

### DIFF
--- a/build-logic/convention/src/main/kotlin/AndroidApplicationConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidApplicationConventionPlugin.kt
@@ -21,28 +21,7 @@ class AndroidApplicationConventionPlugin : Plugin<Project> {
       }
 
       extensions.getByType<KotlinAndroidProjectExtension>().apply {
-        compilerOptions {
-          // Treat all Kotlin warnings as errors (disabled by default)
-          allWarningsAsErrors.set(
-            properties["warningsAsErrors"] as? Boolean ?: false
-          )
-
-          freeCompilerArgs.set(
-            freeCompilerArgs.getOrElse(emptyList()) + listOf(
-              "-Xcontext-receivers",
-              "-Xopt-in=kotlin.RequiresOptIn",
-              // Enable experimental coroutines APIs, including Flow
-              "-Xopt-in=kotlinx.coroutines.ExperimentalCoroutinesApi",
-              // Enable experimental compose APIs
-              "-Xopt-in=androidx.compose.material3.ExperimentalMaterial3Api",
-              "-Xopt-in=androidx.lifecycle.compose.ExperimentalLifecycleComposeApi",
-              "-Xopt-in=androidx.compose.animation.ExperimentalSharedTransitionApi",
-            )
-          )
-
-          // Set JVM target to 17
-          jvmTarget.set(JvmTarget.JVM_17)
-        }
+        configureKotlinAndroid(this)
       }
     }
   }

--- a/build-logic/convention/src/main/kotlin/AndroidApplicationConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidApplicationConventionPlugin.kt
@@ -22,6 +22,7 @@ class AndroidApplicationConventionPlugin : Plugin<Project> {
 
       extensions.getByType<KotlinAndroidProjectExtension>().apply {
         compilerOptions {
+          // Treat all Kotlin warnings as errors (disabled by default)
           allWarningsAsErrors.set(
             properties["warningsAsErrors"] as? Boolean ?: false
           )
@@ -39,6 +40,7 @@ class AndroidApplicationConventionPlugin : Plugin<Project> {
             )
           )
 
+          // Set JVM target to 17
           jvmTarget.set(JvmTarget.JVM_17)
         }
       }

--- a/build-logic/convention/src/main/kotlin/AndroidApplicationConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidApplicationConventionPlugin.kt
@@ -3,6 +3,9 @@ import com.skydoves.pokedex.compose.configureKotlinAndroid
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.configure
+import org.gradle.kotlin.dsl.getByType
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.dsl.KotlinAndroidProjectExtension
 
 class AndroidApplicationConventionPlugin : Plugin<Project> {
   override fun apply(target: Project) {
@@ -15,6 +18,29 @@ class AndroidApplicationConventionPlugin : Plugin<Project> {
       extensions.configure<BaseAppModuleExtension> {
         configureKotlinAndroid(this)
         defaultConfig.targetSdk = 34
+      }
+
+      extensions.getByType<KotlinAndroidProjectExtension>().apply {
+        compilerOptions {
+          allWarningsAsErrors.set(
+            properties["warningsAsErrors"] as? Boolean ?: false
+          )
+
+          freeCompilerArgs.set(
+            freeCompilerArgs.getOrElse(emptyList()) + listOf(
+              "-Xcontext-receivers",
+              "-Xopt-in=kotlin.RequiresOptIn",
+              // Enable experimental coroutines APIs, including Flow
+              "-Xopt-in=kotlinx.coroutines.ExperimentalCoroutinesApi",
+              // Enable experimental compose APIs
+              "-Xopt-in=androidx.compose.material3.ExperimentalMaterial3Api",
+              "-Xopt-in=androidx.lifecycle.compose.ExperimentalLifecycleComposeApi",
+              "-Xopt-in=androidx.compose.animation.ExperimentalSharedTransitionApi",
+            )
+          )
+
+          jvmTarget.set(JvmTarget.JVM_17)
+        }
       }
     }
   }

--- a/build-logic/convention/src/main/kotlin/AndroidFeatureConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidFeatureConventionPlugin.kt
@@ -5,6 +5,8 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.configure
 import org.gradle.kotlin.dsl.dependencies
+import org.gradle.kotlin.dsl.getByType
+import org.jetbrains.kotlin.gradle.dsl.KotlinAndroidProjectExtension
 
 class AndroidFeatureConventionPlugin : Plugin<Project> {
   override fun apply(target: Project) {
@@ -26,6 +28,10 @@ class AndroidFeatureConventionPlugin : Plugin<Project> {
         configureKotlinAndroid(this)
         configureAndroidCompose(this)
         defaultConfig.targetSdk = 34
+      }
+
+      extensions.getByType<KotlinAndroidProjectExtension>().apply {
+        configureKotlinAndroid(this)
       }
     }
   }

--- a/build-logic/convention/src/main/kotlin/AndroidLibraryConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidLibraryConventionPlugin.kt
@@ -3,6 +3,8 @@ import com.skydoves.pokedex.compose.configureKotlinAndroid
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.configure
+import org.gradle.kotlin.dsl.getByType
+import org.jetbrains.kotlin.gradle.dsl.KotlinAndroidProjectExtension
 
 class AndroidLibraryConventionPlugin : Plugin<Project> {
   override fun apply(target: Project) {
@@ -15,6 +17,10 @@ class AndroidLibraryConventionPlugin : Plugin<Project> {
       extensions.configure<LibraryExtension> {
         configureKotlinAndroid(this)
         defaultConfig.targetSdk = 34
+      }
+
+      extensions.getByType<KotlinAndroidProjectExtension>().apply {
+        configureKotlinAndroid(this)
       }
     }
   }

--- a/build-logic/convention/src/main/kotlin/com/skydoves/pokedex/compose/KotlinAndroid.kt
+++ b/build-logic/convention/src/main/kotlin/com/skydoves/pokedex/compose/KotlinAndroid.kt
@@ -3,6 +3,8 @@ package com.skydoves.pokedex.compose
 import com.android.build.api.dsl.CommonExtension
 import org.gradle.api.JavaVersion
 import org.gradle.api.Project
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.dsl.KotlinAndroidProjectExtension
 
 /**
  * Configure base Kotlin with Android options
@@ -24,6 +26,35 @@ internal fun Project.configureKotlinAndroid(
 
     lint {
       abortOnError = false
+    }
+  }
+}
+
+internal fun Project.configureKotlinAndroid(
+  extension: KotlinAndroidProjectExtension,
+) {
+  extension.apply {
+    compilerOptions {
+      // Treat all Kotlin warnings as errors (disabled by default)
+      allWarningsAsErrors.set(
+        properties["warningsAsErrors"] as? Boolean ?: false
+      )
+
+      freeCompilerArgs.set(
+        freeCompilerArgs.getOrElse(emptyList()) + listOf(
+          "-Xcontext-receivers",
+          "-Xopt-in=kotlin.RequiresOptIn",
+          // Enable experimental coroutines APIs, including Flow
+          "-Xopt-in=kotlinx.coroutines.ExperimentalCoroutinesApi",
+          // Enable experimental compose APIs
+          "-Xopt-in=androidx.compose.material3.ExperimentalMaterial3Api",
+          "-Xopt-in=androidx.lifecycle.compose.ExperimentalLifecycleComposeApi",
+          "-Xopt-in=androidx.compose.animation.ExperimentalSharedTransitionApi",
+        )
+      )
+
+      // Set JVM target to 17
+      jvmTarget.set(JvmTarget.JVM_17)
     }
   }
 }

--- a/build-logic/convention/src/main/kotlin/com/skydoves/pokedex/compose/KotlinAndroid.kt
+++ b/build-logic/convention/src/main/kotlin/com/skydoves/pokedex/compose/KotlinAndroid.kt
@@ -3,11 +3,6 @@ package com.skydoves.pokedex.compose
 import com.android.build.api.dsl.CommonExtension
 import org.gradle.api.JavaVersion
 import org.gradle.api.Project
-import org.gradle.api.artifacts.VersionCatalogsExtension
-import org.gradle.api.plugins.ExtensionAware
-import org.gradle.kotlin.dsl.dependencies
-import org.gradle.kotlin.dsl.getByType
-import org.jetbrains.kotlin.gradle.dsl.KotlinJvmOptions
 
 /**
  * Configure base Kotlin with Android options
@@ -30,28 +25,5 @@ internal fun Project.configureKotlinAndroid(
     lint {
       abortOnError = false
     }
-
-    kotlinOptions {
-      // Treat all Kotlin warnings as errors (disabled by default)
-      allWarningsAsErrors = properties["warningsAsErrors"] as? Boolean ?: false
-
-      freeCompilerArgs = freeCompilerArgs + listOf(
-        "-Xcontext-receivers",
-        "-opt-in=kotlin.RequiresOptIn",
-        // Enable experimental coroutines APIs, including Flow
-        "-opt-in=kotlinx.coroutines.ExperimentalCoroutinesApi",
-        // Enable experimental compose APIs
-        "-opt-in=androidx.compose.material3.ExperimentalMaterial3Api",
-        "-opt-in=androidx.lifecycle.compose.ExperimentalLifecycleComposeApi",
-        "-opt-in=androidx.compose.animation.ExperimentalSharedTransitionApi",
-      )
-
-      // Set JVM target to 17
-      jvmTarget = JavaVersion.VERSION_17.toString()
-    }
   }
-}
-
-fun CommonExtension<*, *, *, *, *, *>.kotlinOptions(block: KotlinJvmOptions.() -> Unit) {
-  (this as ExtensionAware).extensions.configure("kotlinOptions", block)
 }


### PR DESCRIPTION
### 🎯 Goal
- Migrate `kotlinOptions` to `compilerOptions` function due to `kotlinOptions` is deprecated.

### 🛠 Implementation details
- I'd apply compilerOptions, but it is registered on `KotlinAndroidProjectExtension`, not BaseExtension. So I've to separate this code block to `configureKotlinAndroid`. So the result of migration is below.

```kotlin
// KotlinAndroid.kt

/*
* ETC
*/

// Newly added configuration function for `KotlinAndroidProjectExtension`
internal fun Project.configureKotlinAndroid(
  extension: KotlinAndroidProjectExtension,
) {
  extension.apply {
    compilerOptions {
      // Treat all Kotlin warnings as errors (disabled by default)
      allWarningsAsErrors.set(
        properties["warningsAsErrors"] as? Boolean ?: false
      )

      freeCompilerArgs.set(
        freeCompilerArgs.getOrElse(emptyList()) + listOf(
          "-Xcontext-receivers",
          "-Xopt-in=kotlin.RequiresOptIn",
          // Enable experimental coroutines APIs, including Flow
          "-Xopt-in=kotlinx.coroutines.ExperimentalCoroutinesApi",
          // Enable experimental compose APIs
          "-Xopt-in=androidx.compose.material3.ExperimentalMaterial3Api",
          "-Xopt-in=androidx.lifecycle.compose.ExperimentalLifecycleComposeApi",
          "-Xopt-in=androidx.compose.animation.ExperimentalSharedTransitionApi",
        )
      )

      // Set JVM target to 17
      jvmTarget.set(JvmTarget.JVM_17)
    }
  }
}

// AndroidApplicationConventionPlugin
class AndroidApplicationConventionPlugin : Plugin<Project> {
  override fun apply(target: Project) {
    with(target) {
      // ...etc

      // Newly Added
      extensions.getByType<KotlinAndroidProjectExtension>().apply {
        configureKotlinAndroid(this)
      }
    }
  }
}

// Also same as Library, Feature convention plugin
```


### ✍️ Explain examples
- [Link about depreaction of `kotlinOptions` call](https://kotlinlang.org/docs/whatsnew18.html#limitations)

### Preparing a pull request for review
Ensure your change is properly formatted by running:

```gradle
$ ./gradlew spotlessApply
```

Please correct any failures before requesting a review.