### PR TITLE
Fix naming inconsistency for PokedexBackground data class

### DIFF
--- a/core/designsystem/src/main/kotlin/com/skydoves/pokedex/compose/core/designsystem/theme/PokedexBackground.kt
+++ b/core/designsystem/src/main/kotlin/com/skydoves/pokedex/compose/core/designsystem/theme/PokedexBackground.kt
@@ -27,20 +27,20 @@ import androidx.compose.ui.unit.dp
 import com.skydoves.pokedex.compose.designsystem.R
 
 @Immutable
-public data class PokdexBackground(
+public data class PokedexBackground(
   val color: Color = Color.Unspecified,
   val tonalElevation: Dp = Dp.Unspecified,
 ) {
   public companion object {
     @Composable
-    public fun defaultBackground(darkTheme: Boolean): PokdexBackground {
+    public fun defaultBackground(darkTheme: Boolean): PokedexBackground {
       return if (darkTheme) {
-        PokdexBackground(
+        PokedexBackground(
           color = colorResource(id = R.color.background_dark),
           tonalElevation = 0.dp,
         )
       } else {
-        PokdexBackground(
+        PokedexBackground(
           color = colorResource(id = R.color.background),
           tonalElevation = 0.dp,
         )
@@ -49,5 +49,5 @@ public data class PokdexBackground(
   }
 }
 
-public val LocalBackgroundTheme: ProvidableCompositionLocal<PokdexBackground> =
-  staticCompositionLocalOf { PokdexBackground() }
+public val LocalBackgroundTheme: ProvidableCompositionLocal<PokedexBackground> =
+  staticCompositionLocalOf { PokedexBackground() }

--- a/core/designsystem/src/main/kotlin/com/skydoves/pokedex/compose/core/designsystem/theme/PokedexTheme.kt
+++ b/core/designsystem/src/main/kotlin/com/skydoves/pokedex/compose/core/designsystem/theme/PokedexTheme.kt
@@ -45,7 +45,7 @@ public fun PokedexTheme(
   } else {
     PokedexColors.defaultLightColors()
   },
-  background: PokdexBackground = PokdexBackground.defaultBackground(darkTheme),
+  background: PokedexBackground = PokedexBackground.defaultBackground(darkTheme),
   content: @Composable () -> Unit,
 ) {
   CompositionLocalProvider(
@@ -76,9 +76,9 @@ public object PokedexTheme {
     get() = LocalColors.current
 
   /**
-   * Retrieves the current [PokdexBackground] at the call site's position in the hierarchy.
+   * Retrieves the current [PokedexBackground] at the call site's position in the hierarchy.
    */
-  public val background: PokdexBackground
+  public val background: PokedexBackground
     @Composable
     @ReadOnlyComposable
     get() = LocalBackgroundTheme.current


### PR DESCRIPTION
### 🎯 Goal
Fixes a typo in the `PokedexBackground` data class name, which was previously written as `PokdexBackground` (missing an 'e').

### 🛠 Implementation details
- Renamed `PokdexBackground` → `PokedexBackground`
- Updated all usages and imports accordingly
- Ensures consistent naming with other Pokedex-related classes

### ✍️ Explain examples
**Before:**
```kotlin
data class PokdexBackground(
  // class implementation
)
```

**After:**
```kotlin
data class PokedexBackground(
  // class implementation
)
```

### ✅ Checklist
- All usages and imports have been updated
- Verified build passes locally
- Ran code formatting:
  ```bash
  ./gradlew spotlessApply
  ```