### PR TITLE
Add dataExtractionRules to suppress allowBackup deprecation warning and ensure compatibility with Android 12+ backup policies

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -7,7 +7,7 @@
     You may obtain a copy of the License at
 
       http://www.apache.org/licenses/LICENSE-2.0
-
+~
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,
     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -22,6 +22,8 @@ xmlns:tools="http://schemas.android.com/tools">
 <application
   android:name=".PokedexApp"
   android:allowBackup="false"
+  android:fullBackupContent="false"
+  android:dataExtractionRules="@xml/no_backup"
   android:enableOnBackInvokedCallback="true"
   android:icon="@mipmap/ic_launcher"
   android:label="@string/app_name"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -7,7 +7,7 @@
     You may obtain a copy of the License at
 
       http://www.apache.org/licenses/LICENSE-2.0
-~
+
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,
     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/app/src/main/res/xml/no_backup.xml
+++ b/app/src/main/res/xml/no_backup.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<data-extraction-rules>
+  <cloud-backup>
+    <exclude domain="root" />
+    <exclude domain="file" />
+    <exclude domain="database" />
+    <exclude domain="sharedpref" />
+    <exclude domain="external" />
+  </cloud-backup>
+  <device-transfer>
+    <exclude domain="root" />
+    <exclude domain="file" />
+    <exclude domain="database" />
+    <exclude domain="sharedpref" />
+    <exclude domain="external" />
+  </device-transfer>
+</data-extraction-rules>

--- a/app/src/main/res/xml/no_backup.xml
+++ b/app/src/main/res/xml/no_backup.xml
@@ -1,4 +1,19 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!--
+    Designed and developed by 2024 skydoves (Jaewoong Eum)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
 <data-extraction-rules>
   <cloud-backup>
     <exclude domain="root" />


### PR DESCRIPTION
### 🎯 Goal

This PR resolves the deprecation warning for `android:allowBackup` attribute that appears when targeting Android 12+ (API 31+). The warning indicates that `android:allowBackup` is deprecated and may be removed in future Android versions, requiring the use of `android:dataExtractionRules` for proper backup policy configuration.

**Warning resolved:**
```
The attribute android:allowBackup is deprecated from Android 12 and higher and may be removed in future versions. Consider adding the attribute android:dataExtractionRules specifying an @xml resource which configures cloud backups and device transfers on Android 12 and higher
```

### 🛠 Implementation details

- **Added** `res/xml/no_backup.xml` file defining data extraction rules that disable all backup operations
- **Updated** `AndroidManifest.xml` to include `android:dataExtractionRules="@xml/no_backup"` attribute
- **Maintained** existing backup policy (disabled) while ensuring compatibility with Android 12+ requirements
- **Preserved** all existing manifest attributes for backward compatibility

The implementation uses explicit exclusion rules for all backup domains:
- `cloud-backup`: Prevents data backup to Google Drive
- `device-transfer`: Prevents data transfer during device migration
- Excludes all domains: `root`, `file`, `database`, `sharedpref`, `external`

### ✍️ Explain examples

**File Structure:**
```
app/src/main/res/xml/no_backup.xml (NEW)
app/src/main/AndroidManifest.xml (MODIFIED)
```

**AndroidManifest.xml changes:**
```xml
<application
    android:name=".PokedexApp"
    android:allowBackup="false"
    android:fullBackupContent="false" <!-- Added this line -->
    android:dataExtractionRules="@xml/no_backup"  <!-- Added this line -->
    android:enableOnBackInvokedCallback="true"
    android:icon="@mipmap/ic_launcher"
    android:label="@string/app_name"
    android:supportsRtl="true"
    android:theme="@style/Theme.PokedexCompose"
    tools:ignore="AllowBackup">
```

**res/xml/no_backup.xml (new file):**
```xml
<?xml version="1.0" encoding="utf-8"?>
<data-extraction-rules>
    <cloud-backup>
        <exclude domain="root" />
        <exclude domain="file" />
        <exclude domain="database" />
        <exclude domain="sharedpref" />
        <exclude domain="external" />
    </cloud-backup>
    <device-transfer>
        <exclude domain="root" />
        <exclude domain="file" />
        <exclude domain="database" />
        <exclude domain="sharedpref" />
        <exclude domain="external" />
    </device-transfer>
</data-extraction-rules>
```

This change:
- ✅ Eliminates the deprecation warning
- ✅ Maintains current backup behavior (disabled)
- ✅ Ensures future Android version compatibility
- ✅ Follows Android 12+ best practices for backup configuration