### PR TITLE
Remove unnecessary Parcelize annotations after Navigation3 migration

### DIFF
--- a/core/model/src/main/kotlin/com/skydoves/pokedex/compose/core/model/Pokemon.kt
+++ b/core/model/src/main/kotlin/com/skydoves/pokedex/compose/core/model/Pokemon.kt
@@ -16,21 +16,18 @@
 
 package com.skydoves.pokedex.compose.core.model
 
-import android.os.Parcelable
 import androidx.compose.runtime.Immutable
-import kotlinx.parcelize.Parcelize
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Immutable
-@Parcelize
 @Serializable
 data class Pokemon(
   var page: Int = 0,
   @SerialName(value = "name")
   val nameField: String,
   @SerialName(value = "url") val url: String,
-) : Parcelable {
+) {
 
   val name: String
     get() = nameField.replaceFirstChar { it.uppercase() }


### PR DESCRIPTION
### 🎯 Goal
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

Remove `@Parcelize` annotation and `Parcelable` interface from model classes
as they are no longer needed after migrating to Navigation3.

Unlike Navigation2, Navigation3 stores arguments directly in memory using `SnapshotStateList` 
instead of Bundle. Therefore, `@Serializable` annotation alone is sufficient, making `@Parcelize` redundant.

reference)
https://android-developers.googleblog.com/2025/05/announcing-jetpack-navigation-3-for-compose.html

https://cs.android.com/androidx/platform/frameworks/support/+/androidx-main:navigation3/navigation3-runtime/src/commonMain/kotlin/androidx/navigation3/runtime/NavBackStack.kt

### 🛠 Implementation details
Describe the implementation details for this Pull Request.

### ✍️ Explain examples
Explain examples with code for this updates.

### Preparing a pull request for review
Ensure your change is properly formatted by running:

```gradle
$ ./gradlew spotlessApply
```

Please correct any failures before requesting a review.