### PR TITLE
Add unit tests for HomeViewModel, DetailsViewModel, and SettingsViewM…

### DIFF
--- a/feature/details/build.gradle.kts
+++ b/feature/details/build.gradle.kts
@@ -6,3 +6,10 @@ plugins {
 android {
   namespace = "com.skydoves.pokedex.compose.feature.details"
 }
+
+dependencies {
+  testImplementation(projects.core.test)
+  testImplementation(libs.kotlinx.coroutines.test)
+  testImplementation(libs.junit)
+  testImplementation(libs.turbine)
+}

--- a/feature/details/src/test/kotlin/com/skydoves/pokedex/compose/feature/details/DetailsViewModelTest.kt
+++ b/feature/details/src/test/kotlin/com/skydoves/pokedex/compose/feature/details/DetailsViewModelTest.kt
@@ -1,0 +1,78 @@
+/*
+ * Designed and developed by 2024 skydoves (Jaewoong Eum)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.skydoves.pokedex.compose.feature.details
+
+import app.cash.turbine.test
+import com.skydoves.pokedex.compose.core.data.repository.details.FakeDetailsRepository
+import com.skydoves.pokedex.compose.core.test.MainCoroutinesRule
+import com.skydoves.pokedex.compose.core.test.MockUtil.mockPokemon
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+class DetailsViewModelTest {
+
+  private lateinit var viewModel: DetailsViewModel
+  private val fakeRepository = FakeDetailsRepository()
+
+  @get:Rule
+  val coroutinesRule = MainCoroutinesRule()
+
+  @Before
+  fun setup() {
+    viewModel = DetailsViewModel(
+      pokemon = mockPokemon(),
+      detailsRepository = fakeRepository,
+    )
+  }
+
+  @Test
+  fun initialUiState_isLoading() {
+    assertEquals(DetailsUiState.Loading, viewModel.uiState.value)
+  }
+
+  @Test
+  fun initialPokemonInfo_isNull() {
+    assertNull(viewModel.pokemonInfo.value)
+  }
+
+  @Test
+  fun pokemonInfo_emitsExpectedData() = runTest {
+    val expected = fakeRepository.mockPokemonInfo()
+
+    viewModel.pokemonInfo.test {
+      val item = awaitItem()
+      assertEquals(expected.id, item?.id)
+      assertEquals(expected.name, item?.name)
+      assertEquals(expected.height, item?.height)
+      assertEquals(expected.weight, item?.weight)
+      cancelAndIgnoreRemainingEvents()
+    }
+  }
+
+  @Test
+  fun uiState_transitionsToIdle_afterSuccessfulFetch() = runTest {
+    viewModel.pokemonInfo.test {
+      awaitItem()
+      cancelAndIgnoreRemainingEvents()
+    }
+    assertEquals(DetailsUiState.Idle, viewModel.uiState.value)
+  }
+}

--- a/feature/home/build.gradle.kts
+++ b/feature/home/build.gradle.kts
@@ -6,3 +6,10 @@ plugins {
 android {
   namespace = "com.skydoves.pokedex.compose.feature.home"
 }
+
+dependencies {
+  testImplementation(projects.core.test)
+  testImplementation(libs.kotlinx.coroutines.test)
+  testImplementation(libs.junit)
+  testImplementation(libs.turbine)
+}

--- a/feature/home/src/test/kotlin/com/skydoves/pokedex/compose/feature/home/HomeViewModelTest.kt
+++ b/feature/home/src/test/kotlin/com/skydoves/pokedex/compose/feature/home/HomeViewModelTest.kt
@@ -1,0 +1,90 @@
+/*
+ * Designed and developed by 2024 skydoves (Jaewoong Eum)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.skydoves.pokedex.compose.feature.home
+
+import app.cash.turbine.test
+import com.skydoves.pokedex.compose.core.data.repository.home.FakeHomeRepository
+import com.skydoves.pokedex.compose.core.test.MainCoroutinesRule
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+class HomeViewModelTest {
+
+  private lateinit var viewModel: HomeViewModel
+
+  @get:Rule
+  val coroutinesRule = MainCoroutinesRule()
+
+  @Before
+  fun setup() {
+    viewModel = HomeViewModel(FakeHomeRepository())
+  }
+
+  @Test
+  fun initialUiState_isLoading() {
+    assertEquals(HomeUiState.Loading, viewModel.uiState.value)
+  }
+
+  @Test
+  fun pokemonList_emitsPokemonFromRepository() = runTest {
+    viewModel.pokemonList.test {
+      val items = awaitItem()
+      assertTrue(items.isNotEmpty())
+      assertEquals("Bulbasaur", items[0].name)
+      cancelAndIgnoreRemainingEvents()
+    }
+  }
+
+  @Test
+  fun uiState_transitionsToIdle_afterPokemonListEmits() = runTest {
+    viewModel.pokemonList.test {
+      awaitItem()
+      cancelAndIgnoreRemainingEvents()
+    }
+    assertEquals(HomeUiState.Idle, viewModel.uiState.value)
+  }
+
+  @Test
+  fun fetchNextPokemonList_doesNotIncrement_whenLoading() {
+    // uiState is Loading before pokemonList is collected
+    assertEquals(HomeUiState.Loading, viewModel.uiState.value)
+    viewModel.fetchNextPokemonList()
+    // state remains Loading — page increment is blocked
+    assertEquals(HomeUiState.Loading, viewModel.uiState.value)
+  }
+
+  @Test
+  fun fetchNextPokemonList_incrementsPage_whenIdle() = runTest {
+    viewModel.pokemonList.test {
+      awaitItem()
+      cancelAndIgnoreRemainingEvents()
+    }
+    assertEquals(HomeUiState.Idle, viewModel.uiState.value)
+
+    viewModel.fetchNextPokemonList()
+
+    viewModel.pokemonList.test {
+      val items = awaitItem()
+      assertTrue(items.isNotEmpty())
+      cancelAndIgnoreRemainingEvents()
+    }
+  }
+}

--- a/feature/settings/build.gradle.kts
+++ b/feature/settings/build.gradle.kts
@@ -4,5 +4,14 @@ plugins {
 }
 
 android {
-    namespace = "com.skydoves.pokedex.compose.feature.settings"
+  namespace = "com.skydoves.pokedex.compose.feature.settings"
+}
+
+dependencies {
+  testImplementation(projects.core.test)
+  testImplementation(libs.kotlinx.coroutines.test)
+  testImplementation(libs.junit)
+  testImplementation(libs.turbine)
+  testImplementation(libs.mockito.core)
+  testImplementation(libs.mockito.kotlin)
 }

--- a/feature/settings/src/test/kotlin/com/skydoves/pokedex/compose/feature/settings/SettingsViewModelTest.kt
+++ b/feature/settings/src/test/kotlin/com/skydoves/pokedex/compose/feature/settings/SettingsViewModelTest.kt
@@ -1,0 +1,97 @@
+/*
+ * Designed and developed by 2024 skydoves (Jaewoong Eum)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.skydoves.pokedex.compose.feature.settings
+
+import app.cash.turbine.test
+import com.skydoves.pokedex.compose.core.model.UiTheme
+import com.skydoves.pokedex.compose.core.model.UserData
+import com.skydoves.pokedex.compose.core.test.MainCoroutinesRule
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+class SettingsViewModelTest {
+
+  private lateinit var viewModel: SettingsViewModel
+  private val userDataRepository: com.skydoves.pokedex.compose.core.data.repository.userdata.UserDataRepository = mock()
+  private val userDataFlow = MutableStateFlow(UserData(uiTheme = UiTheme.FOLLOW_SYSTEM))
+
+  @get:Rule
+  val coroutinesRule = MainCoroutinesRule()
+
+  @Before
+  fun setup() {
+    whenever(userDataRepository.userData).thenReturn(userDataFlow)
+    viewModel = SettingsViewModel(userDataRepository)
+  }
+
+  @Test
+  fun initialUiState_isLoading() {
+    assertEquals(SettingsUiState.Loading, viewModel.uiState.value)
+  }
+
+  @Test
+  fun uiState_emitsSuccess_withDefaultUserData() = runTest {
+    viewModel.uiState.test {
+      assertEquals(
+        SettingsUiState.Success(UserData(UiTheme.FOLLOW_SYSTEM)),
+        awaitItem(),
+      )
+      cancelAndIgnoreRemainingEvents()
+    }
+  }
+
+  @Test
+  fun uiState_updatesWhenUiThemeChanges() = runTest {
+    viewModel.uiState.test {
+      assertEquals(SettingsUiState.Success(UserData(UiTheme.FOLLOW_SYSTEM)), awaitItem())
+
+      userDataFlow.update { it.copy(uiTheme = UiTheme.DARK) }
+      assertEquals(SettingsUiState.Success(UserData(UiTheme.DARK)), awaitItem())
+
+      userDataFlow.update { it.copy(uiTheme = UiTheme.LIGHT) }
+      assertEquals(SettingsUiState.Success(UserData(UiTheme.LIGHT)), awaitItem())
+
+      cancelAndIgnoreRemainingEvents()
+    }
+  }
+
+  @Test
+  fun setUiTheme_dark_delegatesToRepository() = runTest {
+    viewModel.setUiTheme(UiTheme.DARK)
+    verify(userDataRepository).setUiTheme(UiTheme.DARK)
+  }
+
+  @Test
+  fun setUiTheme_light_delegatesToRepository() = runTest {
+    viewModel.setUiTheme(UiTheme.LIGHT)
+    verify(userDataRepository).setUiTheme(UiTheme.LIGHT)
+  }
+
+  @Test
+  fun setUiTheme_followSystem_delegatesToRepository() = runTest {
+    viewModel.setUiTheme(UiTheme.FOLLOW_SYSTEM)
+    verify(userDataRepository).setUiTheme(UiTheme.FOLLOW_SYSTEM)
+  }
+}


### PR DESCRIPTION
Here you go:

---

**🎯 Goal**
Add unit tests for `HomeViewModel`, `DetailsViewModel`, and `SettingsViewModel` which previously had zero test coverage. This improves confidence in the feature layer logic and follows the same testing patterns already established in the `core/data` module.

**🛠 Implementation details**
- Added `HomeViewModelTest` (5 tests), `DetailsViewModelTest` (4 tests), and `SettingsViewModelTest` (6 tests)
- Used the project's existing `FakeHomeRepository` and `FakeDetailsRepository` for Home and Details tests — consistent with the project's fake-first testing approach
- Used Mockito for `SettingsViewModel` to verify `setUiTheme()` is correctly delegated to the repository
- Added test dependencies (`core:test`, `coroutines-test`, `junit`, `turbine`) to each feature module's `build.gradle.kts`
- All tests follow the existing patterns: `MainCoroutinesRule`, `runTest`, and Turbine's `.test { }` for Flow assertions

**✍️ Explain examples**
```kotlin
@Test
fun uiState_transitionsToIdle_afterPokemonListEmits() = runTest {
  viewModel.pokemonList.test {
    awaitItem()
    cancelAndIgnoreRemainingEvents()
  }
  assertEquals(HomeUiState.Idle, viewModel.uiState.value)
}
```

**Preparing a pull request for review**
```
$ ./gradlew spotlessApply
```

---